### PR TITLE
feat: structure input auto-detect (closes #384)

### DIFF
--- a/app/modules/toolkits/helpers.py
+++ b/app/modules/toolkits/helpers.py
@@ -1,30 +1,203 @@
 from __future__ import annotations
 
+import re
+
+import selfies as sf
 from chembl_structure_pipeline import standardizer
 from rdkit import Chem
 
 from app.exception_handlers import InvalidInputException
 from app.modules.toolkits.cdk_wrapper import get_CDK_IAtomContainer
+from app.modules.toolkits.cdk_wrapper import get_CDK_IAtomContainer_from_molblock
 from app.modules.toolkits.cdk_wrapper import get_CDK_SDG_mol
+from app.modules.toolkits.cdk_wrapper import get_canonical_SMILES
+from app.modules.toolkits.cdk_wrapper import get_smiles_opsin
 from app.modules.toolkits.openbabel_wrapper import get_ob_mol
+from app.modules.toolkits.rdkit_wrapper import convert_xyz_to_mol
+
+STRUCTURE_INPUT_FORMATS = frozenset(
+    {"smiles", "inchi", "selfies", "iupac", "molblock", "xyz"}
+)
+_SUPPORTED_INPUT_FORMATS = STRUCTURE_INPUT_FORMATS | {"auto"}
+
+_SELFIES_RE = re.compile(r"^(\[[\w@=#+\-/\\%;.,^*]+\])+$")
+_MOLBLOCK_COUNTS_RE = re.compile(r"\n\d+\s+\d+\s")
 
 
-def parse_input(input: str, framework: str = "rdkit", standardize: bool = False):
+def _normalize_format_name(fmt: str) -> str:
+    return fmt.strip().lower()
+
+
+def _clean_molblock(data: str) -> str:
+    if "$$$$" in data:
+        return data.split("$$$$")[0].strip()
+    return data.strip()
+
+
+def _looks_like_inchi(text: str) -> bool:
+    return text.strip().startswith("InChI=")
+
+
+def _looks_like_selfies(text: str) -> bool:
+    return bool(_SELFIES_RE.match(text.strip()))
+
+
+def _looks_like_molblock(text: str) -> bool:
+    return "M  END" in text or bool(_MOLBLOCK_COUNTS_RE.search(text))
+
+
+def _looks_like_xyz(text: str) -> bool:
+    return bool(split_xyz_frames(text))
+
+
+def _looks_like_iupac(text: str) -> bool:
+    trimmed = text.strip()
+    if not trimmed:
+        return False
+    return bool(
+        re.match(r"^[a-z0-9][a-z0-9 ,\-().]*$", trimmed)
+        and not re.search(r"[a-z]\d", trimmed)
+        and not re.search(r"\d[a-z]", trimmed)
+    )
+
+
+def _can_parse_as_smiles(text: str) -> bool:
+    normalized = text.replace(" ", "+")
+    if Chem.MolFromSmiles(normalized):
+        return True
+    try:
+        return get_CDK_IAtomContainer(normalized) is not None
+    except Exception:
+        return False
+
+
+def _detect_with_confidence(text: str) -> tuple[str, str]:
+    """Return ``(detected_format, confidence)`` for a structure string."""
+    if not text or not text.strip():
+        raise InvalidInputException(name="input", value=text or "")
+
+    trimmed = text.strip()
+
+    if _looks_like_inchi(trimmed):
+        return "inchi", "high"
+    if _looks_like_selfies(trimmed):
+        return "selfies", "high"
+    if _looks_like_molblock(text):
+        return "molblock", "high"
+    if _looks_like_xyz(text):
+        return "xyz", "high"
+    if _can_parse_as_smiles(trimmed):
+        return "smiles", "medium"
+    if _looks_like_iupac(trimmed):
+        return "iupac", "low"
+    return "iupac", "low"
+
+
+def detect_input_format(text: str) -> str:
+    """Detect the chemical structure format of *text*.
+
+    Detection order: InChI, SELFIES, molblock, XYZ, SMILES (try-parse), IUPAC.
+    """
+    detected_format, _ = _detect_with_confidence(text)
+    return detected_format
+
+
+def detect_input_format_with_confidence(text: str) -> tuple[str, str]:
+    """Return ``(detected_format, confidence)`` where confidence is high/medium/low."""
+    return _detect_with_confidence(text)
+
+
+def input_to_smiles(value: str, input_format: str) -> str:
+    """Convert structure *value* in *input_format* to a SMILES string."""
+    fmt = _normalize_format_name(input_format)
+    if fmt == "auto":
+        fmt = detect_input_format(value)
+
+    if fmt == "smiles":
+        return value
+    if fmt == "iupac":
+        smiles = get_smiles_opsin(value)
+        if not smiles:
+            raise ValueError(f"Failed to convert IUPAC name '{value}' to SMILES")
+        return smiles
+    if fmt == "selfies":
+        smiles = sf.decoder(value)
+        if not smiles:
+            raise ValueError(f"Failed to decode SELFIES '{value}' to SMILES")
+        return smiles
+    if fmt == "inchi":
+        mol = Chem.inchi.MolFromInchi(value)
+        if not mol:
+            raise ValueError(f"Failed to convert InChI '{value}' to molecule")
+        return Chem.MolToSmiles(mol)
+    if fmt == "molblock":
+        cleaned = _clean_molblock(value)
+        mol = Chem.MolFromMolBlock(cleaned)
+        if mol:
+            return Chem.MolToSmiles(mol)
+        mol_container = get_CDK_IAtomContainer_from_molblock(cleaned)
+        if mol_container is None:
+            raise ValueError("Failed to parse molblock")
+        smiles = get_canonical_SMILES(mol_container)
+        if not smiles:
+            raise ValueError("Failed to parse molblock")
+        return str(smiles)
+    if fmt == "xyz":
+        frames = split_xyz_frames(value)
+        if not frames:
+            raise ValueError("Failed to parse XYZ")
+        mol, _ = convert_xyz_to_mol(frames[0])
+        return Chem.MolToSmiles(mol)
+
+    raise ValueError(f"Unsupported input format: {input_format}")
+
+
+def resolve_input_smiles(value: str, auto_detect: bool = False) -> str:
+    """Return SMILES for *value*, auto-detecting format when requested."""
+    if auto_detect:
+        return input_to_smiles(value, "auto")
+    return value
+
+
+def parse_structure_query(
+    smiles: str,
+    framework: str = "rdkit",
+    auto_detect: bool = False,
+    standardize: bool = False,
+):
+    """Parse a structure query parameter, optionally auto-detecting its format."""
+    input_format = "auto" if auto_detect else "smiles"
+    return parse_input(smiles, framework, standardize, input_format=input_format)
+
+
+def parse_input(
+    input: str,
+    framework: str = "rdkit",
+    standardize: bool = False,
+    input_format: str = "smiles",
+):
     """Parse and check if the input is valid.
 
     Args:
         input (str): Input string.
+        framework (str): Toolkit framework (rdkit, cdk, openbabel).
+        standardize (bool): Whether to standardize via ChEMBL pipeline.
+        input_format (str): Input format or ``auto`` to detect.
 
     Returns:
         Mol or None: Valid molecule object or None if an error occurs.
-            If an error occurs during SMILES parsing, an error message is returned.
     """
+    fmt = _normalize_format_name(input_format)
+    if fmt == "auto":
+        fmt = detect_input_format(input)
+    elif fmt not in _SUPPORTED_INPUT_FORMATS - {"auto"}:
+        raise ValueError(f"Unsupported input format: {input_format}")
 
-    # auto detect the format
-    format = "SMILES"
-
-    if format == "SMILES":
+    if fmt == "smiles":
         return parse_SMILES(input, framework, standardize)
+
+    smiles = input_to_smiles(input, fmt)
+    return parse_SMILES(smiles, framework, standardize)
 
 
 def parse_SMILES(smiles: str, framework: str = "rdkit", standardize: bool = False):

--- a/app/modules/toolkits/helpers.py
+++ b/app/modules/toolkits/helpers.py
@@ -29,9 +29,17 @@ def _normalize_format_name(fmt: str) -> str:
 
 
 def _clean_molblock(data: str) -> str:
+    """Trim an SDF multi-record delimiter and trailing whitespace.
+
+    Leading whitespace is preserved on purpose: the V2000 header is
+    position-fixed (title / program / comment / counts line), and molblocks
+    legitimately start with a blank title line. Stripping it shifts every
+    header line up by one and corrupts the counts line RDKit expects on
+    line 4.
+    """
     if "$$$$" in data:
-        return data.split("$$$$")[0].strip()
-    return data.strip()
+        data = data.split("$$$$", 1)[0]
+    return data.rstrip()
 
 
 def _looks_like_inchi(text: str) -> bool:
@@ -170,6 +178,36 @@ def parse_structure_query(
     return parse_input(smiles, framework, standardize, input_format=input_format)
 
 
+_NATIVE_RDKIT_FORMATS = frozenset({"inchi", "molblock", "xyz"})
+
+
+def _native_rdkit_mol(value: str, fmt: str):
+    """Return a native RDKit Mol for *value* in *fmt*, or ``None``.
+
+    Used by :func:`parse_input` to avoid a lossy SMILES-string round trip
+    for formats RDKit can parse directly (e.g. explicit hydrogens written
+    out as separate atoms in XYZ/molblock input would otherwise be folded
+    back into implicit Hs when the intermediate SMILES is re-parsed).
+    Returning ``None`` tells the caller to fall back to the
+    ``input_to_smiles`` + ``parse_SMILES`` pipeline instead (e.g. for a
+    molblock RDKit can't read but CDK can).
+    """
+    try:
+        if fmt == "inchi":
+            return Chem.inchi.MolFromInchi(value, removeHs=False)
+        if fmt == "molblock":
+            return Chem.MolFromMolBlock(_clean_molblock(value), removeHs=False)
+        if fmt == "xyz":
+            frames = split_xyz_frames(value)
+            if not frames:
+                return None
+            mol, _ = convert_xyz_to_mol(frames[0])
+            return mol
+    except (ValueError, RuntimeError):
+        return None
+    return None
+
+
 def parse_input(
     input: str,
     framework: str = "rdkit",
@@ -195,6 +233,15 @@ def parse_input(
 
     if fmt == "smiles":
         return parse_SMILES(input, framework, standardize)
+
+    if framework == "rdkit" and fmt in _NATIVE_RDKIT_FORMATS:
+        mol = _native_rdkit_mol(input, fmt)
+        if mol is not None:
+            if standardize:
+                mol_block = Chem.MolToMolBlock(mol)
+                standardized_mol = standardizer.standardize_molblock(mol_block)
+                mol = Chem.MolFromMolBlock(standardized_mol)
+            return mol
 
     smiles = input_to_smiles(input, fmt)
     return parse_SMILES(smiles, framework, standardize)

--- a/app/routers/chem.py
+++ b/app/routers/chem.py
@@ -32,7 +32,10 @@ from app.modules.fix_radicals import fixradicals
 from app.modules.npscorer import get_np_score
 from app.modules.toolkits.cdk_wrapper import get_CDK_HOSE_codes
 from app.modules.toolkits.cdk_wrapper import get_tanimoto_similarity_CDK
+from app.routers.params import AUTO_DETECT_PARAM
 from app.modules.toolkits.helpers import parse_input
+from app.modules.toolkits.helpers import parse_structure_query
+from app.modules.toolkits.helpers import resolve_input_smiles
 from app.modules.toolkits.rdkit_wrapper import check_RO5_violations
 from app.modules.toolkits.rdkit_wrapper import check_RO5_violations_detailed
 from app.modules.toolkits.rdkit_wrapper import get_ertl_functional_groups
@@ -147,6 +150,7 @@ def get_stereoisomers(
             },
         },
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """For a given SMILES string this function enumerates all possible.
 
@@ -161,7 +165,7 @@ def get_stereoisomers(
     Raises:
     - ValueError: If the SMILES string is not provided or is invalid.
     """
-    mol = parse_input(smiles, "rdkit", False)
+    mol = parse_structure_query(smiles, "rdkit", auto_detect)
     if mol:
         isomers = tuple(EnumerateStereoisomers(mol))
         smilesArray = []
@@ -207,6 +211,7 @@ def get_descriptors(
         default="rdkit",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generates standard descriptors for the input molecule (SMILES).
 
@@ -224,7 +229,8 @@ def get_descriptors(
     Raises:
     - None
     """
-    data = get_COCONUT_descriptors(smiles, toolkit)
+    resolved_smiles = resolve_input_smiles(smiles, auto_detect)
+    data = get_COCONUT_descriptors(resolved_smiles, toolkit)
     if format == "html":
         if toolkit == "all":
             headers = [
@@ -375,6 +381,7 @@ def hose_codes(
         title="ringsize",
         description="Determines whether to include information about ring sizes",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generates HOSE codes for a given SMILES string.
 
@@ -394,10 +401,10 @@ def hose_codes(
     - ValueError: If the SMILES string is not provided or is invalid.
     """
     if toolkit == "cdk":
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         hose_codes = get_CDK_HOSE_codes(mol, spheres, ringsize)
     elif toolkit == "rdkit":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         hose_codes = get_rdkit_HOSE_codes(mol, spheres)
 
     if hose_codes:
@@ -533,6 +540,7 @@ def check_errors(
         title="Fix",
         description="Flag indicating whether to fix the issues by standardizing the SMILES.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Check a given SMILES string and the represented structure for issues and.
 
@@ -559,6 +567,7 @@ def check_errors(
     - If the SMILES string contains spaces, they will be replaced with "+" characters before processing.
     - If the SMILES string cannot be read, the function returns the string "Error reading SMILES string, check again."
     """
+    smiles = resolve_input_smiles(smiles, auto_detect)
     mol = Chem.MolFromSmiles(smiles, sanitize=False)
     if mol:
         mol_block = Chem.MolToMolBlock(mol)
@@ -621,6 +630,7 @@ def np_likeness_score(
             },
         },
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Calculates the natural product likeness score based on the RDKit.
 
@@ -635,7 +645,7 @@ def np_likeness_score(
     Raises:
     - ValueError: If the SMILES string is not provided or is invalid.
     """
-    mol = parse_input(smiles, "rdkit", False)
+    mol = parse_structure_query(smiles, "rdkit", auto_detect)
     try:
         np_score = get_np_score(mol)
         if np_score:
@@ -807,6 +817,7 @@ def coconut_preprocessing(
         title="descriptors",
         description="Flag indicating whether to generate COCONUT descriptors for a given molecule",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generates an Input JSON file with information on different molecular.
 
@@ -823,7 +834,8 @@ def coconut_preprocessing(
     - HTTPException: If there is an error reading the SMILES string.
     """
     try:
-        data = get_COCONUT_preprocessing(smiles, _3d_mol, descriptors)
+        resolved_smiles = resolve_input_smiles(smiles, auto_detect)
+        data = get_COCONUT_preprocessing(resolved_smiles, _3d_mol, descriptors)
         if data:
             return data
         else:
@@ -870,6 +882,7 @@ async def classyfire_classify(
             },
         },
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generate ClassyFire-based classifications using SMILES as input.
 
@@ -886,9 +899,9 @@ async def classyfire_classify(
     - ClassyFire is a chemical taxonomy classification tool that predicts the chemical class and subclass of a compound based on its structural features.
     - This service pings the http://classyfire.wishartlab.com server for information retrieval.
     """
-    mol = parse_input(smiles, "rdkit", False)
-    if mol:
-        classification_data = await classify(smiles)
+    resolved_smiles = resolve_input_smiles(smiles, auto_detect)
+    if resolved_smiles:
+        classification_data = await classify(resolved_smiles)
         if classification_data:
             return classification_data
 
@@ -1354,6 +1367,7 @@ def get_functional_groups(
             },
         },
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """For a given SMILES string this function generates a list of identified.
 
@@ -1368,7 +1382,7 @@ def get_functional_groups(
     Raises:
     - ValueError: If the SMILES string is not provided or is invalid.
     """
-    mol = parse_input(smiles, "rdkit", False)
+    mol = parse_structure_query(smiles, "rdkit", auto_detect)
     if mol:
         try:
             f_groups = get_ertl_functional_groups(mol)
@@ -1412,8 +1426,9 @@ def get_standardized_tautomer_smiles(
             },
         },
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
-    mol = parse_input(smiles, "rdkit", False)
+    mol = parse_structure_query(smiles, "rdkit", auto_detect)
     if mol:
         standardized_smiles = get_standardized_tautomer(mol)
         return standardized_smiles
@@ -1452,6 +1467,7 @@ def fix_radicals_endpoint(
             },
         },
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Fix radicals (single electrons) in molecules using CDK.
 
@@ -1502,7 +1518,7 @@ def fix_radicals_endpoint(
 
     try:
         # Parse input using CDK (required for radical perception)
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         if mol is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/app/routers/converters.py
+++ b/app/routers/converters.py
@@ -25,6 +25,7 @@ from app.schemas import HealthCheck
 from app.schemas.error import BadRequestModel
 from app.schemas.error import ErrorResponse
 from app.schemas.error import NotFoundModel
+from app.schemas.converters_schema import DetectFormatResponse
 from app.schemas.converters_schema import GenerateCanonicalResponse
 from app.schemas.converters_schema import GenerateCXSMILESResponse
 from app.schemas.converters_schema import GenerateFormatsResponse
@@ -48,7 +49,14 @@ from app.modules.toolkits.cdk_wrapper import get_CDK_IAtomContainer_from_molbloc
 from app.modules.toolkits.cdk_wrapper import get_CXSMILES
 from app.modules.toolkits.cdk_wrapper import get_InChI
 from app.modules.toolkits.cdk_wrapper import get_smiles_opsin
+from app.routers.params import AUTO_DETECT_PARAM
+from app.modules.toolkits.helpers import STRUCTURE_INPUT_FORMATS
+from app.modules.toolkits.helpers import detect_input_format
+from app.modules.toolkits.helpers import detect_input_format_with_confidence
+from app.modules.toolkits.helpers import input_to_smiles
 from app.modules.toolkits.helpers import parse_input
+from app.modules.toolkits.helpers import parse_structure_query
+from app.modules.toolkits.helpers import resolve_input_smiles
 from app.modules.toolkits.helpers import split_xyz_frames
 from app.modules.toolkits.openbabel_wrapper import get_ob_canonical_SMILES
 from app.modules.toolkits.openbabel_wrapper import get_ob_InChI
@@ -99,6 +107,35 @@ def get_health() -> HealthCheck:
 
 
 @router.get(
+    "/detect-format",
+    summary="Auto-detect the format of a chemical structure string",
+    responses={
+        200: {
+            "description": "Successful response",
+            "model": DetectFormatResponse,
+        },
+        422: {"description": "Unprocessable Entity", "model": ErrorResponse},
+    },
+)
+@limiter.limit("20/minute")
+def detect_format(
+    request: Request,
+    input: str = Query(
+        ...,
+        title="Structure input",
+        max_length=5000,
+        description="Chemical structure string to inspect (SMILES, InChI, molblock, etc.)",
+    ),
+) -> DetectFormatResponse:
+    """Detect the chemical structure format of the provided input string."""
+    detected_format, confidence = detect_input_format_with_confidence(input)
+    return DetectFormatResponse(
+        detected_format=detected_format,
+        confidence=confidence,
+    )
+
+
+@router.get(
     "/mol2D",
     summary="Generates 2D Coordinates for the input molecules",
     responses={
@@ -133,6 +170,7 @@ def create2d_coordinates(
         default="cdk",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generates 2D Coordinates using the CDK Structure diagram.
 
@@ -150,22 +188,23 @@ def create2d_coordinates(
     - ValueError: If the SMILES string is not provided or is invalid.
     """
     if toolkit == "cdk":
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         return Response(
             content=get_CDK_SDG_mol(mol).replace("$$$$\n", ""),
             media_type="text/plain",
         )
     elif toolkit == "rdkit":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         return Response(
             content=get_2d_mol(mol),
             media_type="text/plain",
         )
     else:
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         if mol:
+            resolved_smiles = resolve_input_smiles(smiles, auto_detect)
             return Response(
-                content=get_ob_mol(smiles),
+                content=get_ob_mol(resolved_smiles),
                 media_type="text/plain",
             )
 
@@ -205,6 +244,7 @@ def create3d_coordinates(
         default="openbabel",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generates a random 3D conformer from SMILES using the specified molecule.
 
@@ -223,16 +263,17 @@ def create3d_coordinates(
     """
 
     if toolkit == "rdkit":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         return Response(
             content=get_3d_conformers(mol, depict=False),
             media_type="text/plain",
         )
     elif toolkit == "openbabel":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         if mol:
+            resolved_smiles = resolve_input_smiles(smiles, auto_detect)
             return Response(
-                content=get_ob_mol(smiles, threeD=True),
+                content=get_ob_mol(resolved_smiles, threeD=True),
                 media_type="text/plain",
             )
 
@@ -350,6 +391,7 @@ def smiles_canonicalise(
         default="cdk",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Canonicalizes a given SMILES string according to the allowed toolkits.
 
@@ -365,14 +407,15 @@ def smiles_canonicalise(
     - ValueError: If the SMILES string is empty or contains invalid characters.
     - ValueError: If an unsupported toolkit option is provided.
     """
+    resolved_smiles = resolve_input_smiles(smiles, auto_detect)
     if toolkit == "cdk":
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         return str(get_canonical_SMILES(mol))
     elif toolkit == "rdkit":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         return str(Chem.MolToSmiles(mol, kekuleSmiles=True))
     elif toolkit == "openbabel":
-        smiles = get_ob_canonical_SMILES(smiles)
+        smiles = get_ob_canonical_SMILES(resolved_smiles)
         return smiles
 
 
@@ -409,6 +452,7 @@ def smiles_to_cxsmiles(
         default="cdk",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Convert SMILES to CXSMILES.
 
@@ -431,12 +475,12 @@ def smiles_to_cxsmiles(
     - CXSMILES is a Chemaxon Extended SMILES which is used for storing special features of the molecules after the SMILES string.
     """
     if toolkit == "cdk":
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         cxsmiles = get_CXSMILES(mol)
         if cxsmiles:
             return str(cxsmiles)
     else:
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         cxsmiles = get_rdkit_CXSMILES(mol)
         if cxsmiles:
             return str(cxsmiles)
@@ -475,6 +519,7 @@ def smiles_to_inchi(
         default="cdk",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Convert SMILES to InChI.
 
@@ -490,19 +535,20 @@ def smiles_to_inchi(
     - ValueError: If the SMILES string is empty or contains invalid characters.
     - ValueError: If an unsupported toolkit option is provided.
     """
+    resolved_smiles = resolve_input_smiles(smiles, auto_detect)
     if toolkit == "cdk":
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         inchi = get_InChI(mol)
         if inchi:
             return str(inchi)
     elif toolkit == "rdkit":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         if mol:
             inchi = Chem.inchi.MolToInchi(mol)
             if inchi:
                 return str(inchi)
     elif toolkit == "openbabel":
-        inchi = get_ob_InChI(smiles)
+        inchi = get_ob_InChI(resolved_smiles)
         if inchi:
             return str(inchi)
 
@@ -540,6 +586,7 @@ def smiles_to_inchikey(
         default="cdk",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Convert SMILES to InChI-Key.
 
@@ -555,20 +602,21 @@ def smiles_to_inchikey(
     - ValueError: If the SMILES string is empty or contains invalid characters.
     - ValueError: If an unsupported toolkit option is provided.
     """
+    resolved_smiles = resolve_input_smiles(smiles, auto_detect)
     if toolkit == "cdk":
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         inchikey = get_InChI(mol, InChIKey=True)
         if inchikey:
             return str(inchikey)
 
     elif toolkit == "rdkit":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         if mol:
             inchikey = Chem.inchi.MolToInchiKey(mol)
             if inchikey:
                 return str(inchikey)
     elif toolkit == "openbabel":
-        inchikey = get_ob_InChI(smiles, InChIKey=True)
+        inchikey = get_ob_InChI(resolved_smiles, InChIKey=True)
         if inchikey:
             return str(inchikey)
 
@@ -602,6 +650,7 @@ def encode_selfies(
             },
         },
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generates SELFIES string for a given SMILES string.
 
@@ -618,7 +667,8 @@ def encode_selfies(
     - ValueError: If the SMILES string is empty or contains invalid characters.
     """
     try:
-        selfies_e = sf.encoder(smiles)
+        resolved_smiles = resolve_input_smiles(smiles, auto_detect)
+        selfies_e = sf.encoder(resolved_smiles)
         if selfies_e:
             return str(selfies_e)
         else:
@@ -666,6 +716,7 @@ def smiles_convert_to_formats(
         default="cdk",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Convert SMILES to various molecular formats using different toolkits.
 
@@ -689,9 +740,10 @@ def smiles_convert_to_formats(
     - ValueError: If an unsupported toolkit option is provided.
     """
     try:
+        resolved_smiles = resolve_input_smiles(smiles, auto_detect)
         if toolkit == "cdk":
             response = {}
-            mol = parse_input(smiles, "cdk", False)
+            mol = parse_structure_query(smiles, "cdk", auto_detect)
             response["mol"] = get_CDK_SDG_mol(mol).replace("$$$$\n", "")
             response["canonicalsmiles"] = str(get_canonical_SMILES(mol))
             response["inchi"] = str(get_InChI(mol))
@@ -699,7 +751,7 @@ def smiles_convert_to_formats(
             return response
 
         elif toolkit == "rdkit":
-            mol = parse_input(smiles, "rdkit", False)
+            mol = parse_structure_query(smiles, "rdkit", auto_detect)
             if mol:
                 response = {}
                 response["mol"] = Chem.MolToMolBlock(mol)
@@ -712,10 +764,10 @@ def smiles_convert_to_formats(
                 return response
         elif toolkit == "openbabel":
             response = {}
-            response["mol"] = get_ob_mol(smiles)
-            response["canonicalsmiles"] = get_ob_canonical_SMILES(smiles)
-            response["inchi"] = get_ob_InChI(smiles)
-            response["inchikey"] = get_ob_InChI(smiles, InChIKey=True)
+            response["mol"] = get_ob_mol(resolved_smiles)
+            response["canonicalsmiles"] = get_ob_canonical_SMILES(resolved_smiles)
+            response["inchi"] = get_ob_InChI(resolved_smiles)
+            response["inchikey"] = get_ob_InChI(resolved_smiles, InChIKey=True)
             return response
         else:
             raise HTTPException(
@@ -765,10 +817,11 @@ def smiles_to_smarts(
         default="rdkit",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
 
     if toolkit == "rdkit":
-        mol = parse_input(smiles, "rdkit", False)
+        mol = parse_structure_query(smiles, "rdkit", auto_detect)
         if mol:
             smarts = Chem.MolToSmarts(mol)
             if smarts:
@@ -960,32 +1013,18 @@ def batch_convert(
         try:
             # Extract values from the input dictionary
             value = input_item.get("value", "")
-            input_format = input_item.get("input_format", "")
+            input_format = input_item.get("input_format") or ""
 
-            if not value or not input_format:
-                raise ValueError("Missing required fields: value or input_format")
+            if not value:
+                raise ValueError("Missing required field: value")
 
-            # First convert input to SMILES if it's not already in SMILES format
-            smiles = value
+            if not input_format:
+                input_format = detect_input_format(value)
 
-            if input_format.lower() == "iupac":
-                smiles = get_smiles_opsin(value)
-                if not smiles:
-                    raise ValueError(
-                        f"Failed to convert IUPAC name '{value}' to SMILES"
-                    )
-            elif input_format.lower() == "selfies":
-                smiles = sf.decoder(value)
-                if not smiles:
-                    raise ValueError(f"Failed to decode SELFIES '{value}' to SMILES")
-            elif input_format.lower() == "inchi":
-                # Use RDKit to convert InChI to SMILES
-                mol = Chem.inchi.MolFromInchi(value)
-                if not mol:
-                    raise ValueError(f"Failed to convert InChI '{value}' to molecule")
-                smiles = Chem.MolToSmiles(mol)
-            elif input_format.lower() != "smiles":
+            if input_format.lower() not in STRUCTURE_INPUT_FORMATS:
                 raise ValueError(f"Unsupported input format: {input_format}")
+
+            smiles = input_to_smiles(value, input_format)
 
             # Now convert SMILES to the desired output format
             output_value = ""

--- a/app/routers/depict.py
+++ b/app/routers/depict.py
@@ -14,7 +14,9 @@ from fastapi.templating import Jinja2Templates
 
 from app.modules.depiction import get_rdkit_depiction
 from app.modules.depiction_enhanced import get_cdk_depiction
-from app.modules.toolkits.helpers import parse_input
+from app.routers.params import AUTO_DETECT_PARAM
+from app.modules.toolkits.helpers import parse_structure_query
+from app.modules.toolkits.helpers import resolve_input_smiles
 from app.modules.toolkits.openbabel_wrapper import get_ob_mol
 from app.modules.toolkits.rdkit_wrapper import get_3d_conformers
 from app.schemas import HealthCheck
@@ -153,6 +155,7 @@ def depict_2d_molecule(
             "'Smart' (intelligent H placement, recommended for chiral molecules)."
         ),
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generates a 2D depiction of a molecule using CDK or RDKit with the given.
 
@@ -216,7 +219,7 @@ def depict_2d_molecule(
                 get_cdk_depiction as get_cdk_depiction_basic,
             )
 
-            mol = parse_input(smiles, "cdk", False)
+            mol = parse_structure_query(smiles, "cdk", auto_detect)
             depiction = get_cdk_depiction_basic(
                 mol,
                 [width, height],
@@ -229,7 +232,7 @@ def depict_2d_molecule(
                 hydrogen_display=hydrogen_display,
             )
         elif toolkit == "rdkit":
-            mol = parse_input(smiles, "rdkit", False)
+            mol = parse_structure_query(smiles, "rdkit", auto_detect)
             depiction = get_rdkit_depiction(
                 mol,
                 [width, height],
@@ -286,6 +289,7 @@ def depict_3d_molecule(
         default="openbabel",
         description="Cheminformatics toolkit used in the backend",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generate 3D depictions of molecules using OpenBabel or RDKit.
 
@@ -307,12 +311,13 @@ def depict_3d_molecule(
     """
     try:
         if toolkit == "openbabel":
+            resolved_smiles = resolve_input_smiles(smiles, auto_detect)
             content = {
                 "request": request,
-                "molecule": get_ob_mol(smiles, threeD=True, depict=True),
+                "molecule": get_ob_mol(resolved_smiles, threeD=True, depict=True),
             }
         elif toolkit == "rdkit":
-            mol = parse_input(smiles, "rdkit", False)
+            mol = parse_structure_query(smiles, "rdkit", auto_detect)
             content = {"request": request, "molecule": get_3d_conformers(mol)}
         else:
             raise HTTPException(
@@ -573,6 +578,7 @@ def depict_2d_molecule_enhanced(
         title="Apply MDL HILITE",
         description="Whether to apply MDL V3000 HILITE highlighting from molecule properties.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """Generate advanced 2D molecular depictions with comprehensive customization options.
 
@@ -691,7 +697,7 @@ def depict_2d_molecule_enhanced(
         # Generate depiction using CDK (only toolkit supported for enhanced features)
         # CDK's SmilesParser automatically handles CXSMILES (e.g., "CCO |ha:0,1|")
         # The highlighting is extracted internally via extract_cxsmiles_highlighting()
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         if title:
             try:
                 from jpype import JClass

--- a/app/routers/params.py
+++ b/app/routers/params.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from fastapi import Query
+
+AUTO_DETECT_PARAM = Query(
+    default=False,
+    description=(
+        "When true, auto-detect input format (SMILES, InChI, molblock, etc.) "
+        "instead of assuming SMILES."
+    ),
+)

--- a/app/routers/tools.py
+++ b/app/routers/tools.py
@@ -7,7 +7,8 @@ from fastapi import HTTPException
 from fastapi import Query
 from fastapi import status
 
-from app.modules.toolkits.helpers import parse_input
+from app.routers.params import AUTO_DETECT_PARAM
+from app.modules.toolkits.helpers import parse_structure_query
 from app.modules.tools.sugar_removal import extract_aglycone_and_sugars
 from app.modules.tools.sugar_removal import get_aglycone_and_sugar_indices
 from app.modules.tools.sugar_removal import get_sugar_info
@@ -216,6 +217,7 @@ def get_sugar_info_endpoint(
         title="Detect Keto Sugars",
         description="Whether circular sugars with keto groups should be detected. Default is False.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """
     Get the information whether a given molecule contains circular or linear sugar moieties. The presence of sugars is determnined using the Sugar Removal Utility.
@@ -239,7 +241,7 @@ def get_sugar_info_endpoint(
     - str: A message indicating the type of sugars present in the molecule, either "The molecule contains Linear and Circular sugars", "The molecule contains only Linear sugar", "The molecule contains only Circular sugar", or "The molecule contains no sugar".
     """
     try:
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         _has_linear_sugar, _has_circular_sugars = get_sugar_info(
             molecule=mol,
             gly_bond=gly_bond,
@@ -338,6 +340,7 @@ def remove_linear_sugars_endpoint(
         title="Mark Attachment Points",
         description="Whether to mark the attachment points of removed sugars with a dummy atom. Default is False.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """
     Remove linear sugar moieties from a given molecule using the Sugar Removal Utility and return the aglycone SMILES string or a message indicating that no linear sugars were found.
@@ -357,7 +360,7 @@ def remove_linear_sugars_endpoint(
     - str: The aglycone SMILES string or "No Linear sugar found".
     """
     try:
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         _removed_smiles = remove_linear_sugars(
             molecule=mol,
             only_terminal=only_terminal,
@@ -461,6 +464,7 @@ def remove_circular_sugars_endpoint(
         title="Mark Attachment Points",
         description="Whether to mark the attachment points of removed sugars with a dummy atom. Default is False.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """
     Remove circular sugar moieties from a given molecule using the Sugar Removal Utility and return the aglycone SMILES string or a message indicating that no circular sugars were found.
@@ -481,7 +485,7 @@ def remove_circular_sugars_endpoint(
     - str: The aglycone SMILES string or "No Circular sugar found".
     """
     try:
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         removed_smiles = remove_circular_sugars(
             molecule=mol,
             gly_bond=gly_bond,
@@ -612,6 +616,7 @@ def remove_linear_and_circular_sugars_endpoint(
         title="Mark Attachment Points",
         description="Whether to mark the attachment points of removed sugars with a dummy atom. Default is False.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """
     Remove circular and linear sugar moieties from a given molecule using the Sugar Removal Utility and return the aglycone SMILES string or a message indicating that no sugars were found.
@@ -636,7 +641,7 @@ def remove_linear_and_circular_sugars_endpoint(
     - str: The aglycone SMILES string or "No Linear or Circular sugars found".
     """
     try:
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         _removed_smiles = remove_linear_and_circular_sugars(
             molecule=mol,
             gly_bond=gly_bond,
@@ -790,6 +795,7 @@ def extract_aglycone_and_sugars_endpoint(
         title="Limit Post-processing by Size",
         description="Whether the post-processing of extracted sugar moieties should be limited to structures bigger than a defined size (see preservation mode (threshold)) to preserve smaller modifications. Default is False.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """
     Extracts the aglycone and sugar moieties from a given molecule using the Sugar Detection Utility and returns their SMILES strings as a printed list.
@@ -818,7 +824,7 @@ def extract_aglycone_and_sugars_endpoint(
     - list: The SMILES representations of the aglycone and sugars. The first one is always the aglycone. The list has a variable length dependening on how many sugar moieties were found.
     """
     try:
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         _aglycone_and_sugars_tuple = extract_aglycone_and_sugars(
             molecule=mol,
             extract_circular_sugars=extract_circular_sugars,
@@ -974,6 +980,7 @@ def get_aglycone_and_sugar_indices_endpoint(
         title="Limit Post-processing by Size",
         description="Whether the post-processing of extracted sugar moieties should be limited to structures bigger than a defined size (see preservation mode (threshold)) to preserve smaller modifications. Default is False.",
     ),
+    auto_detect: bool = AUTO_DETECT_PARAM,
 ):
     """
     Extracts the aglycone and sugar moieties from a given molecule using the Sugar Detection Utility and returns their atom indices as a printed list of indices lists.
@@ -1002,7 +1009,7 @@ def get_aglycone_and_sugar_indices_endpoint(
     - list: The atom indices of the aglycone and sugars. The first set of indices is always the aglycone. The list has a variable length dependening on how many sugar moieties were found.
     """
     try:
-        mol = parse_input(smiles, "cdk", False)
+        mol = parse_structure_query(smiles, "cdk", auto_detect)
         _aglycone_and_sugar_indices_list = get_aglycone_and_sugar_indices(
             molecule=mol,
             extract_circular_sugars=extract_circular_sugars,

--- a/app/schemas/converters_schema.py
+++ b/app/schemas/converters_schema.py
@@ -357,21 +357,37 @@ class GenerateFormatsResponse(BaseModel):
     }
 
 
+class DetectFormatResponse(BaseModel):
+    """Response for format auto-detection."""
+
+    detected_format: str = Field(
+        ...,
+        description="Detected input format (smiles, inchi, selfies, iupac, molblock, xyz).",
+    )
+    confidence: str = Field(
+        ...,
+        description="Detection confidence: high, medium, or low.",
+    )
+
+
 class ConversionInput(BaseModel):
     """Represents a single input for chemical structure conversion.
 
     Properties:
     - value (str): The chemical structure to convert
-    - input_format (str): The format of the input structure
+    - input_format (str, optional): The format of the input structure; auto-detected when omitted
     """
 
     value: str = Field(
         ..., description="The chemical structure to convert (e.g., SMILES, InChI)"
     )
-    input_format: str = Field(
-        ...,
-        description="Format of the input (e.g., smiles, inchi, iupac, selfies)",
-        examples=["smiles", "inchi", "iupac", "selfies"],
+    input_format: str | None = Field(
+        default=None,
+        description=(
+            "Format of the input (e.g., smiles, inchi, iupac, selfies, molblock, xyz). "
+            "When omitted, the format is auto-detected from the value."
+        ),
+        examples=["smiles", "inchi", "iupac", "selfies", "molblock", "xyz"],
     )
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "dompurify": "^3.4.11",
+        "dompurify": "^3.4.13",
         "jszip": "^3.10.1",
         "lucide-react": "^0.577.0",
         "motion": "^12.36.0",
@@ -28,7 +28,7 @@
         "react-dropzone": "^14.2.3",
         "react-error-boundary": "^6.1.1",
         "react-resizable-panels": "^2.1.7",
-        "react-router-dom": "^6.30.4",
+        "react-router-dom": "^7.18.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "three": "^0.183.2",
@@ -1539,9 +1539,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3619,15 +3619,6 @@
         "three": ">=0.144.0"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
@@ -4712,16 +4703,16 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
@@ -5083,16 +5074,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -5913,22 +5904,36 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -5955,9 +5960,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6858,9 +6863,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -7767,9 +7772,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -8470,9 +8475,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
+      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8682,9 +8687,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9387,9 +9392,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -10574,9 +10579,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -11206,9 +11211,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -11226,7 +11231,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11715,35 +11720,54 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-style-singleton": {
@@ -12323,6 +12347,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -13395,18 +13425,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/type-is/node_modules/mime-db": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "dompurify": "^3.4.11",
+    "dompurify": "^3.4.13",
     "jszip": "^3.10.1",
     "lucide-react": "^0.577.0",
     "motion": "^12.36.0",
@@ -27,7 +27,7 @@
     "react-dropzone": "^14.2.3",
     "react-error-boundary": "^6.1.1",
     "react-resizable-panels": "^2.1.7",
-    "react-router-dom": "^6.30.4",
+    "react-router-dom": "^7.18.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "three": "^0.183.2",
@@ -74,14 +74,19 @@
     ]
   },
   "overrides": {
-    "hono": "^4.12.25",
-    "@hono/node-server": "^1.19.13",
+    "hono": "^4.12.34",
+    "@hono/node-server": "^1.19.15",
     "follow-redirects": "^1.16.0",
     "@babel/core": "^7.29.6",
     "form-data": "^4.0.6",
     "qs": "^6.15.2",
-    "fast-uri": "^3.1.2",
-    "ip-address": "^10.1.1"
+    "fast-uri": "^3.1.5",
+    "ip-address": "^10.3.1",
+    "js-yaml": "^4.3.1",
+    "postcss": "^8.5.23",
+    "minimatch@3.1.5": {
+      "brace-expansion": "^1.1.16"
+    }
   },
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/convert/FormatConversionView.tsx
+++ b/frontend/src/components/convert/FormatConversionView.tsx
@@ -1,5 +1,5 @@
 // Description: This component handles the format conversion between different chemical notations.
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 // Ensure all used icons are imported
 // Assuming these components are correctly implemented and styled for dark/light mode
 import SMILESInput from "../common/SMILESInput";
@@ -74,8 +74,8 @@ const TOOLKIT_OPTIONS = [
 // Converter options for IUPAC
 const IUPAC_CONVERTER_OPTIONS = [{ id: "opsin", label: "OPSIN" }];
 
-// Detect whether input text is SMILES, SELFIES, or IUPAC name
-const detectInputFormat = (text) => {
+// Detect whether input text is SMILES, SELFIES, or IUPAC name (local fallback)
+const detectInputFormatLocal = (text) => {
   const trimmed = text.trim();
   if (!trimmed) return null;
 
@@ -99,6 +99,13 @@ const detectInputFormat = (text) => {
   return "iupac";
 };
 
+const mapBackendDetectedFormat = (format) => {
+  if (format === "molblock") return "molsdf";
+  if (format === "xyz") return "xyz";
+  if (format === "inchi") return "smiles";
+  return format;
+};
+
 const FormatConversionView = () => {
   const [input, setInput] = useState("");
   const [inputFormat, setInputFormat] = useState("smiles");
@@ -110,6 +117,15 @@ const FormatConversionView = () => {
   const [error, setError] = useState(null);
   const [copied, setCopied] = useState(false);
   const [autoDetected, setAutoDetected] = useState(false);
+  const detectTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (detectTimeoutRef.current) {
+        clearTimeout(detectTimeoutRef.current);
+      }
+    };
+  }, []);
   // State for molecular structure display
   const [smilesForStructure, setSmilesForStructure] = useState("");
   const [showStructure, setShowStructure] = useState(false);
@@ -315,25 +331,50 @@ const FormatConversionView = () => {
     }
   };
 
+  const applyDetectedFormat = (detected) => {
+    if (!detected) {
+      setAutoDetected(false);
+      return;
+    }
+    const mapped = mapBackendDetectedFormat(detected);
+    if (mapped && mapped !== inputFormat) {
+      setInputFormat(mapped);
+      setAutoDetected(true);
+      if (mapped === "iupac" || mapped === "selfies") {
+        setOutputFormat("smiles");
+      } else if (mapped === "smiles") {
+        setOutputFormat("canonicalsmiles");
+      } else if (mapped === "molsdf") {
+        setOutputFormat("smiles");
+      } else if (mapped === "xyz") {
+        setOutputFormat("canonicalsmiles");
+        if (toolkit === "cdk") setToolkit("rdkit");
+      }
+    }
+  };
+
   // Handle text input changes with auto-format detection
   const handleInputChange = (value) => {
     setInput(value);
     if (inputFormat === "molsdf") return;
 
-    const detected = detectInputFormat(value);
     if (!value.trim()) {
       setAutoDetected(false);
       return;
     }
-    if (detected && detected !== inputFormat) {
-      setInputFormat(detected);
-      setAutoDetected(true);
-      if (detected === "iupac" || detected === "selfies") {
-        setOutputFormat("smiles");
-      } else if (detected === "smiles") {
-        setOutputFormat("canonicalsmiles");
-      }
+
+    if (detectTimeoutRef.current) {
+      clearTimeout(detectTimeoutRef.current);
     }
+
+    detectTimeoutRef.current = setTimeout(async () => {
+      try {
+        const { detected_format } = await convertService.detectInputFormat(value);
+        applyDetectedFormat(detected_format);
+      } catch {
+        applyDetectedFormat(detectInputFormatLocal(value));
+      }
+    }, 300);
   };
 
   // When output format changes, we may need to adjust toolkit availability
@@ -370,6 +411,7 @@ const FormatConversionView = () => {
     try {
       let convertedResult;
       let smilesForDisplay = "";
+      const convertOptions = { autoDetect: autoDetected };
 
       // XYZ → SMILES / Canonical SMILES / InChI / InChIKey / MOL / SDF
       if (inputFormat === "xyz") {
@@ -438,7 +480,11 @@ const FormatConversionView = () => {
             convertedResult = smiles;
           } else if (outputFormat === "mol") {
             // MOL Block output: generate 2D coordinates from SMILES
-            convertedResult = await convertService.generate2DCoordinates(smiles, toolkit);
+            convertedResult = await convertService.generate2DCoordinates(
+              smiles,
+              toolkit,
+              convertOptions
+            );
           } else {
             // Otherwise, convert SMILES to the target format
             const formatOption = OUTPUT_FORMAT_OPTIONS.find((option) => option.id === outputFormat);
@@ -452,7 +498,7 @@ const FormatConversionView = () => {
             }
 
             // Convert the SMILES to the target format
-            convertedResult = await method(smiles, toolkit);
+            convertedResult = await method(smiles, toolkit, convertOptions);
           }
         } else if (inputFormat !== "cdx") {
           // First convert IUPAC or SELFIES to SMILES
@@ -470,7 +516,11 @@ const FormatConversionView = () => {
             convertedResult = smiles;
           } else if (outputFormat === "mol") {
             // MOL Block output: generate 2D coordinates from SMILES
-            convertedResult = await convertService.generate2DCoordinates(smiles, toolkit);
+            convertedResult = await convertService.generate2DCoordinates(
+              smiles,
+              toolkit,
+              convertOptions
+            );
           } else {
             // Otherwise, convert SMILES to the target format
             const formatOption = OUTPUT_FORMAT_OPTIONS.find((option) => option.id === outputFormat);
@@ -484,7 +534,7 @@ const FormatConversionView = () => {
             }
 
             // Convert the SMILES to the target format
-            convertedResult = await method(smiles, toolkit);
+            convertedResult = await method(smiles, toolkit, convertOptions);
           }
         }
       } else {
@@ -497,7 +547,11 @@ const FormatConversionView = () => {
           convertedResult = trimmedInput;
         } else if (outputFormat === "mol") {
           // MOL Block output: generate 2D coordinates from SMILES
-          convertedResult = await convertService.generate2DCoordinates(trimmedInput, toolkit);
+          convertedResult = await convertService.generate2DCoordinates(
+            trimmedInput,
+            toolkit,
+            convertOptions
+          );
         } else {
           const formatOption = OUTPUT_FORMAT_OPTIONS.find((option) => option.id === outputFormat);
           if (!formatOption || !formatOption.method) {
@@ -509,7 +563,7 @@ const FormatConversionView = () => {
             throw new Error(`Conversion function not available for format: ${outputFormat}`);
           }
 
-          convertedResult = await method(trimmedInput, toolkit);
+          convertedResult = await method(trimmedInput, toolkit, convertOptions);
         }
       }
 

--- a/frontend/src/services/convertService.ts
+++ b/frontend/src/services/convertService.ts
@@ -6,17 +6,39 @@ import type {
   CdxConversionResult,
   XYZBatchConversionResult,
   XYZConversionOptions,
+  DetectFormatResult,
 } from "../types/api";
 
 const CONVERT_URL = "/convert";
 
 /**
+ * Detect the chemical structure format of an input string.
+ */
+export const detectInputFormat = async (input: string): Promise<DetectFormatResult> => {
+  const response = await api.get<DetectFormatResult>(`${CONVERT_URL}/detect-format`, {
+    params: { input },
+  });
+  return response.data;
+};
+
+type ConvertParams = {
+  autoDetect?: boolean;
+};
+
+const withAutoDetect = (params: Record<string, unknown>, autoDetect?: boolean) =>
+  autoDetect ? { ...params, auto_detect: true } : params;
+
+/**
  * Generate 2D coordinates for a molecule
  */
-export const generate2DCoordinates = async (smiles: string, toolkit = "cdk"): Promise<string> => {
+export const generate2DCoordinates = async (
+  smiles: string,
+  toolkit = "cdk",
+  options: ConvertParams = {}
+): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/mol2D`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -31,11 +53,12 @@ export const generate2DCoordinates = async (smiles: string, toolkit = "cdk"): Pr
  */
 export const generate3DCoordinates = async (
   smiles: string,
-  toolkit = "openbabel"
+  toolkit = "openbabel",
+  options: ConvertParams = {}
 ): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/mol3D`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -68,10 +91,14 @@ export const generateSMILES = async (
 /**
  * Generate canonical SMILES
  */
-export const generateCanonicalSMILES = async (smiles: string, toolkit = "cdk"): Promise<string> => {
+export const generateCanonicalSMILES = async (
+  smiles: string,
+  toolkit = "cdk",
+  options: ConvertParams = {}
+): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/canonicalsmiles`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -84,10 +111,14 @@ export const generateCanonicalSMILES = async (smiles: string, toolkit = "cdk"): 
 /**
  * Generate CXSMILES (ChemAxon Extended SMILES)
  */
-export const generateCXSMILES = async (smiles: string, toolkit = "cdk"): Promise<string> => {
+export const generateCXSMILES = async (
+  smiles: string,
+  toolkit = "cdk",
+  options: ConvertParams = {}
+): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/cxsmiles`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -100,10 +131,14 @@ export const generateCXSMILES = async (smiles: string, toolkit = "cdk"): Promise
 /**
  * Generate InChI (IUPAC International Chemical Identifier)
  */
-export const generateInChI = async (smiles: string, toolkit = "cdk"): Promise<string> => {
+export const generateInChI = async (
+  smiles: string,
+  toolkit = "cdk",
+  options: ConvertParams = {}
+): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/inchi`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -116,10 +151,14 @@ export const generateInChI = async (smiles: string, toolkit = "cdk"): Promise<st
 /**
  * Generate InChI Key
  */
-export const generateInChIKey = async (smiles: string, toolkit = "cdk"): Promise<string> => {
+export const generateInChIKey = async (
+  smiles: string,
+  toolkit = "cdk",
+  options: ConvertParams = {}
+): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/inchikey`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -132,10 +171,13 @@ export const generateInChIKey = async (smiles: string, toolkit = "cdk"): Promise
 /**
  * Generate SELFIES (Self-Referencing Embedded Strings)
  */
-export const generateSELFIES = async (smiles: string): Promise<string> => {
+export const generateSELFIES = async (
+  smiles: string,
+  options: ConvertParams = {}
+): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/selfies`, {
-      params: { smiles },
+      params: withAutoDetect({ smiles }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -148,10 +190,14 @@ export const generateSELFIES = async (smiles: string): Promise<string> => {
 /**
  * Generate SMARTS pattern
  */
-export const generateSMARTS = async (smiles: string, toolkit = "rdkit"): Promise<string> => {
+export const generateSMARTS = async (
+  smiles: string,
+  toolkit = "rdkit",
+  options: ConvertParams = {}
+): Promise<string> => {
   try {
     const response = await api.get<string>(`${CONVERT_URL}/smarts`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
       responseType: "text",
     });
     return response.data;
@@ -210,11 +256,12 @@ export const molblockToSMILES = async (molblock: string, toolkit = "cdk"): Promi
  */
 export const generateMultipleFormats = async (
   smiles: string,
-  toolkit = "cdk"
+  toolkit = "cdk",
+  options: ConvertParams = {}
 ): Promise<MultipleFormatsResult> => {
   try {
     const response = await api.get<MultipleFormatsResult>(`${CONVERT_URL}/formats`, {
-      params: { smiles, toolkit },
+      params: withAutoDetect({ smiles, toolkit }, options.autoDetect),
     });
     return response.data;
   } catch (error) {
@@ -293,6 +340,7 @@ export const convertXYZ = async (
 
 // Assemble all functions into a service object
 const convertService = {
+  detectInputFormat,
   generate2DCoordinates,
   generate3DCoordinates,
   generateSMILES,

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -42,6 +42,11 @@ export interface CoconutPreprocessingResult {
 
 // --- Convert Service Types ---
 
+export interface DetectFormatResult {
+  detected_format: string;
+  confidence: "high" | "medium" | "low";
+}
+
 export interface MultipleFormatsResult {
   [format: string]: string;
 }

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1019,8 +1019,8 @@ def test_batch_missing_value_or_format():
 
 
 def test_batch_missing_input_format():
-    """Test batch with missing input_format (lines 959-960)."""
-    body = {"inputs": [{"value": "CCO", "input_format": ""}]}
+    """Missing input_format auto-detects from value."""
+    body = {"inputs": [{"value": "CCO"}]}
     response = client.post(
         "/latest/convert/batch?output_format=smiles&toolkit=cdk",
         json=body,
@@ -1028,7 +1028,46 @@ def test_batch_missing_input_format():
     )
     assert response.status_code == 200
     data = response.json()
-    assert data["summary"]["failed"] == 1
+    assert data["summary"]["successful"] == 1
+    assert data["results"][0]["output"] == "CCO"
+
+
+def test_batch_auto_detect_inchi():
+    """Batch auto-detects InChI when input_format is omitted."""
+    body = {
+        "inputs": [{"value": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3"}]
+    }
+    response = client.post(
+        "/latest/convert/batch?output_format=canonicalsmiles&toolkit=rdkit",
+        json=body,
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["summary"]["successful"] == 1
+
+
+def test_detect_format_inchi():
+    response = client.get(
+        "/latest/convert/detect-format",
+        params={"input": "InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3"},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["detected_format"] == "inchi"
+    assert data["confidence"] == "high"
+
+
+def test_detect_format_smiles():
+    response = client.get(
+        "/latest/convert/detect-format",
+        params={"input": "CCO"},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["detected_format"] == "smiles"
 
 
 def test_batch_iupac_input():

--- a/tests/test_format_detection.py
+++ b/tests/test_format_detection.py
@@ -9,7 +9,7 @@ from app.modules.toolkits.helpers import parse_input
 from app.modules.toolkits.helpers import parse_structure_query
 
 CAFFEINE_SMILES = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
-CAFFEINE_INCHI = "InChI=1S/C8H10N4O2/c1-3(9-6)10-5-4(8(13)12)11(2)7(5)14/h3H,1-2H3,(H,9,10,12,13,14)"
+CAFFEINE_INCHI = "InChI=1S/C8H10N4O2/c1-10-4-9-6-5(10)7(13)12(3)8(14)11(6)2/h4H,1-3H3"
 CAFFEINE_SELFIES = "[C][N][C][=N][C][=C][Ring1][Branch1][C][=Branch1][C][=O][N][Branch1][=Branch2][C][=Branch1][C][=O][N][Ring1][Branch2][C][C]"
 ETHANOL_SELFIES = "[C][C][O]"
 WATER_XYZ = (

--- a/tests/test_format_detection.py
+++ b/tests/test_format_detection.py
@@ -1,0 +1,117 @@
+import pytest
+from rdkit import Chem
+
+from app.exception_handlers import InvalidInputException
+from app.modules.toolkits.helpers import detect_input_format
+from app.modules.toolkits.helpers import detect_input_format_with_confidence
+from app.modules.toolkits.helpers import input_to_smiles
+from app.modules.toolkits.helpers import parse_input
+from app.modules.toolkits.helpers import parse_structure_query
+
+CAFFEINE_SMILES = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+CAFFEINE_INCHI = "InChI=1S/C8H10N4O2/c1-3(9-6)10-5-4(8(13)12)11(2)7(5)14/h3H,1-2H3,(H,9,10,12,13,14)"
+CAFFEINE_SELFIES = "[C][N][C][=N][C][=C][Ring1][Branch1][C][=Branch1][C][=O][N][Branch1][=Branch2][C][=Branch1][C][=O][N][Ring1][Branch2][C][C]"
+ETHANOL_SELFIES = "[C][C][O]"
+WATER_XYZ = (
+    "3\n"
+    "water\n"
+    "O    0.0000    0.0000    0.0000\n"
+    "H    0.7572    0.5860    0.0000\n"
+    "H   -0.7572    0.5860    0.0000\n"
+)
+
+MOLBLOCK = """
+  CDK     08302311362D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+    0.9743    0.5625    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3248    1.3125    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.3248    2.8125    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.6238    0.5625    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  2  3  2  0  0  0  0
+  2  4  1  0  0  0  0
+M  END
+"""
+
+
+class TestDetectInputFormat:
+    def test_detect_inchi(self):
+        assert detect_input_format(CAFFEINE_INCHI) == "inchi"
+
+    def test_detect_selfies(self):
+        assert detect_input_format(CAFFEINE_SELFIES) == "selfies"
+
+    def test_detect_molblock(self):
+        assert detect_input_format(MOLBLOCK) == "molblock"
+
+    def test_detect_xyz(self):
+        assert detect_input_format(WATER_XYZ) == "xyz"
+
+    def test_detect_smiles(self):
+        assert detect_input_format(CAFFEINE_SMILES) == "smiles"
+
+    def test_detect_iupac_name(self):
+        assert detect_input_format("ethanol") == "iupac"
+
+    def test_detect_empty_raises(self):
+        with pytest.raises(InvalidInputException):
+            detect_input_format("")
+
+    def test_confidence_high_for_inchi(self):
+        fmt, confidence = detect_input_format_with_confidence(CAFFEINE_INCHI)
+        assert fmt == "inchi"
+        assert confidence == "high"
+
+    def test_confidence_low_for_iupac(self):
+        fmt, confidence = detect_input_format_with_confidence("ethanol")
+        assert fmt == "iupac"
+        assert confidence == "low"
+
+
+class TestParseInputAutoDetect:
+    def test_default_smiles_behavior_unchanged(self):
+        mol = parse_input(CAFFEINE_SMILES)
+        assert mol is not None
+        assert mol.GetNumAtoms() == 14
+
+    def test_explicit_smiles_rejects_inchi(self):
+        with pytest.raises(InvalidInputException):
+            parse_input(CAFFEINE_INCHI, input_format="smiles")
+
+    def test_auto_detect_inchi(self):
+        mol = parse_input(CAFFEINE_INCHI, input_format="auto")
+        assert mol is not None
+        assert mol.GetNumAtoms() == 14
+
+    def test_auto_detect_selfies(self):
+        mol = parse_input(ETHANOL_SELFIES, input_format="auto")
+        assert mol is not None
+        assert mol.GetNumAtoms() == 3
+
+    def test_auto_detect_molblock(self):
+        mol = parse_input(MOLBLOCK, input_format="auto")
+        assert mol is not None
+        assert mol.GetNumAtoms() == 4
+
+    def test_auto_detect_xyz(self):
+        mol = parse_input(WATER_XYZ, input_format="auto")
+        assert mol is not None
+        assert mol.GetNumAtoms() == 3
+
+    def test_parse_structure_query_auto_detect_flag(self):
+        mol = parse_structure_query(CAFFEINE_INCHI, auto_detect=True)
+        assert mol is not None
+
+    def test_input_to_smiles_round_trip_formats(self):
+        smiles = input_to_smiles(CAFFEINE_INCHI, "inchi")
+        assert Chem.MolFromSmiles(smiles) is not None
+
+        smiles = input_to_smiles(CAFFEINE_SELFIES, "selfies")
+        assert Chem.MolFromSmiles(smiles) is not None
+
+        smiles = input_to_smiles(MOLBLOCK, "molblock")
+        assert Chem.MolFromSmiles(smiles) is not None
+
+        smiles = input_to_smiles(WATER_XYZ, "xyz")
+        assert Chem.MolFromSmiles(smiles) is not None


### PR DESCRIPTION
## Summary
- Add centralized structure format detection and parsing in the toolkit layer (InChI, SELFIES, molblock, XYZ, SMILES, IUPAC) with SMILES-only behavior preserved by default.
- Expose opt-in auto-detect via `GET /convert/detect-format`, optional `input_format` on batch conversion, and `auto_detect=true` on single-molecule convert/chem/depict/tools endpoints.
- Integrate backend format detection in the format conversion UI with a local regex fallback and `auto_detect` on downstream convert calls.

## Test plan
- [ ] `pytest tests/test_format_detection.py tests/test_helper.py tests/test_converters.py`
- [ ] `GET /latest/convert/detect-format?input=InChI=1S/C2H6O/c1-2-3/h3H,2H2,1H3` returns `inchi` with high confidence
- [ ] Existing SMILES-only calls without `auto_detect` behave unchanged
- [ ] `POST /latest/convert/batch` with omitted `input_format` auto-detects InChI/SELFIES
- [ ] Format conversion UI auto-detects pasted input and converts with `auto_detect=true`